### PR TITLE
Remove accidental throw

### DIFF
--- a/lib/lmify.js
+++ b/lib/lmify.js
@@ -130,7 +130,6 @@ class Lmify extends Transform {
             }]
         }, (err, results) => {
             if (err) {
-                throw err;
                 return callback(err);
             }
             const targetChunk = Buffer.from(results.getChunk);


### PR DESCRIPTION
The throw prevents error handling when used with a gulp pipeline.